### PR TITLE
ics admet prediction tdc

### DIFF
--- a/benchmark/leaderboards.py
+++ b/benchmark/leaderboards.py
@@ -5,6 +5,12 @@ _LEADERBOARDS = {
         "incr", # increasing or descending order
         [
             [
+		"Innoplexus ABDNN-ADME", "Rohit Yadav", "rohit.yadav@ics.innoplexus.com",
+		"https://github.com/Innoplexus-opensource/ics-admet-prediction-tdc/tree/main/", 
+		"https://github.com/Innoplexus-opensource/ics-admet-prediction-tdc/tree/main/report/Innoplexus ADME-NN Model Evaluation on TDC Benchmark ADMET Group Binary Datasets.pdf",
+		"305,794", 0.148
+	    ],
+            [
                 "MapLight", "Jim Notwell", "jnotwell@maplightrx.com", "https://github.com/maplightrx/MapLight-TDC", 
                 "https://arxiv.org/abs/2310.00174", "N/A", 0.276
             ],
@@ -20,6 +26,11 @@ _LEADERBOARDS = {
                 "MolMapNet-D", "Shen Wan Xiang", "wanxiang.shen@u.nus.edu", "https://github.com/shenwanxiang/bidd-molmap/tree\
                     /master/misc/tdc_leaderboard_submission/Caco2_Wang-MolMapNet-D.ipynb", 
                     "https://www.nature.com/articles/s42256-021-00301-6", "407,617", 0.287
+            ],
+            [
+                "Innoplexus ADME", "Rohit Yadav", "rohit.yadav@ics.innoplexus.com", "https://github.com/Innoplexus-opensource/ics-therapeutics-data-commons/tree/main",
+                "https://github.com/Innoplexus-opensource/ics-therapeutics-data-commons/blob/main/Innoplexus_ADME_Model_report.pdf",
+                "N/A", 0.289
             ],
             [
                 "XGBoost", "Andrew Li", "andrew@oloren.ai", "https://github.com/Oloren-AI/OCE-TDC/blob/main/submission.ipynb", 
@@ -57,6 +68,10 @@ _LEADERBOARDS = {
         ], # meta info: model, contact_name, contact_email, GH, repo, .. other .., value to rank by
         [
             [
+		0.148,
+		0.007
+	    ],
+            [
                 0.276,
                 0.005
             ],
@@ -70,6 +85,10 @@ _LEADERBOARDS = {
             ],
             [
                 0.287,
+                0.005
+            ],
+            [
+                0.289,
                 0.005
             ],
             [
@@ -113,6 +132,12 @@ _LEADERBOARDS = {
         ["Rank", "Model", "Contact", "Link", "#Params", "AUROC"],
         "desc",
         [
+            [
+		"Innoplexus ABDNN-ADME", "Rohit Yadav", "rohit.yadav@ics.innoplexus.com",
+		"https://github.com/Innoplexus-opensource/ics-admet-prediction-tdc/tree/main/", 
+		"https://github.com/Innoplexus-opensource/ics-admet-prediction-tdc/tree/main/report/Innoplexus ADME-NN Model Evaluation on TDC Benchmark ADMET Group Binary Datasets.pdf",
+		"305,794", 0.955
+	    ],
             [
                 "HistGradientBoostingClassifier (DeepMol)", "DeepMol Team", "jcapels96@gmail.com", 
                 "https://github.com/BioSystemsUM/deepmol_case_studies", "https://doi.org/10.1101/2024.05.27.595849",
@@ -168,7 +193,11 @@ _LEADERBOARDS = {
                 "https://doi.org/10.1101/2024.05.27.595849", "N/A", 0.617
             ],
         ],
-        [
+        [   
+            [
+		0.955,
+		0.017
+	    ],
             [
                 0.753,
                 0
@@ -225,7 +254,13 @@ _LEADERBOARDS = {
         "old",
         ["Rank", "Model", "Contact", "Link", "#Params", "MAE"],
         "incr",
-        [
+        [   
+            [
+		"Innoplexus ABDNN-ADME", "Rohit Yadav", "rohit.yadav@ics.innoplexus.com",
+		"https://github.com/Innoplexus-opensource/ics-admet-prediction-tdc/tree/main/", 
+		"https://github.com/Innoplexus-opensource/ics-admet-prediction-tdc/tree/main/report/Innoplexus ADME-NN Model Evaluation on TDC Benchmark ADMET Group Binary Datasets.pdf",
+		"305,794", 0.227
+	    ],
             [
                 "Chemprop-RDKit", "Kyle Swanson", "swansonk@stanford.edu", "https://github.com/chemprop/chemprop", 
                 "https://pubs.acs.org/doi/full/10.1021/acs.jcim.9b00237", "N/A", 0.467
@@ -239,8 +274,7 @@ _LEADERBOARDS = {
                 "https://chemrxiv.org/engage/chemrxiv/article-details/6350b9d186473a47d31a8492", "N/A", 0.479
             ],
             [
-                "Innoplexus ADME", "Rohit Yadav", "rohit.yadav@ics.innoplexus.com", 
-                "https://github.com/Innoplexus-opensource/ics-therapeutics-data-commons/tree/main", 
+                "Innoplexus ADME", "Rohit Yadav", "rohit.yadav@ics.innoplexus.com", "https://github.com/Innoplexus-opensource/ics-therapeutics-data-commons/tree/main",
                 "https://github.com/Innoplexus-opensource/ics-therapeutics-data-commons/blob/main/Innoplexus_ADME_Model_report.pdf",
                 "N/A", 0.499
             ],
@@ -288,6 +322,10 @@ _LEADERBOARDS = {
             ],
         ],
         [
+            [
+		0.227,
+		0.018
+	    ],
             [
                 0.467,
                 0.006
@@ -348,15 +386,21 @@ _LEADERBOARDS = {
         "old",
         ["Rank", "Model", "Contact", "Link", "#Params", "MAE" ],
         "incr",
-        [
+        [   
+            [
+		"Innoplexus ABDNN-ADME", "Rohit Yadav", "rohit.yadav@ics.innoplexus.com",
+		"https://github.com/Innoplexus-opensource/ics-admet-prediction-tdc/tree/main/", 
+		"https://github.com/Innoplexus-opensource/ics-admet-prediction-tdc/tree/main/report/Innoplexus ADME-NN Model Evaluation on TDC Benchmark ADMET Group Binary Datasets.pdf",
+		"305,794", 0.387
+	    ], 
             [
                 "Chemprop-RDKit", "Kyle Swanson", "swansonk@stanford.edu", "https://github.com/chemprop/chemprop", 
                 "https://pubs.acs.org/doi/full/10.1021/acs.jcim.9b00237", "N/A", 0.761
             ],
             [
-                "Innoplexus ADME", "Rohit Yadav", "rohit.yadav@ics.innoplexus.com", "https://github.com/Innoplexus-opensource/\
-                    ics-therapeutics-data-commons/tree/main", "https://github.com/Innoplexus-opensource/ics-therapeutics-data\
-                        -commons/blob/main/Innoplexus_ADME_Model_report.pdf", "N/A", 0.771
+                "Innoplexus ADME", "Rohit Yadav", "rohit.yadav@ics.innoplexus.com", "https://github.com/Innoplexus-opensource/ics-therapeutics-data-commons/tree/main",
+                "https://github.com/Innoplexus-opensource/ics-therapeutics-data-commons/blob/main/Innoplexus_ADME_Model_report.pdf",
+                "N/A", 0.771
             ],
             [
                 "DeepMol (AutoML) ", "DeepMol Team", "jcapels96@gmail.com", "https://github.com/BioSystemsUM/deepmol_case_studies",
@@ -394,6 +438,10 @@ _LEADERBOARDS = {
             
         ],
         [
+            [
+		0.387,
+		0.035
+	    ],
             [
                 0.761,
                 0.025
@@ -460,6 +508,12 @@ _LEADERBOARDS = {
                 "N/A", 0.986
             ],
             [
+		"Innoplexus ABDNN-ADME", "Rohit Yadav", "rohit.yadav@ics.innoplexus.com",
+		"https://github.com/Innoplexus-opensource/ics-admet-prediction-tdc/tree/main/", 
+		"https://github.com/Innoplexus-opensource/ics-admet-prediction-tdc/tree/main/report/Innoplexus ADME-NN Model Evaluation on TDC Benchmark ADMET Group Binary Datasets.pdf",
+		"305,794", 0.985
+	    ],
+            [
                 "CFA", "Nan Jiang", "njiang3@fordham.edu", "https://github.com/F-LIDM/CFA4DD", 
                 "https://chemrxiv.org/engage/chemrxiv/article-details/6563ec17cf8b3c3cd73212b3", "N/A", 0.981
             ],
@@ -503,6 +557,10 @@ _LEADERBOARDS = {
                 0.000
             ],
             [
+                0.985,
+                0.029
+            ],
+            [
                 0.981,
                 0.009
             ],
@@ -535,6 +593,12 @@ _LEADERBOARDS = {
         ["Rank", "Model", "Contact", "Link", "#Params", "AUROC" ],
         "desc",
         [
+            [
+		"Innoplexus ABDNN-ADME", "Rohit Yadav", "rohit.yadav@ics.innoplexus.com",
+		"https://github.com/Innoplexus-opensource/ics-admet-prediction-tdc/tree/main/", 
+		"https://github.com/Innoplexus-opensource/ics-admet-prediction-tdc/tree/main/report/Innoplexus ADME-NN Model Evaluation on TDC Benchmark ADMET Group Binary Datasets.pdf",
+		"305,794", 0.985
+	    ],
             [
                 "MapLight + GNN", "Jim Notwell", "jnotwell@maplightrx.com", "https://github.com/maplightrx/MapLight-TDC", 
                 "https://arxiv.org/abs/2310.00174", "N/A", 0.938
@@ -583,6 +647,10 @@ _LEADERBOARDS = {
             ],
         ],
         [
+            [
+		0.985,
+		0.006
+	    ],
             [
                 0.938,
                 0.002
@@ -635,7 +703,13 @@ _LEADERBOARDS = {
         "old",
         ["Rank", "Model", "Contact", "Link", "#Params", "AUROC" ],
         "desc",
-        [
+        [   
+	    [
+		"Innoplexus ABDNN-ADME", "Rohit Yadav", "rohit.yadav@ics.innoplexus.com",
+		"https://github.com/Innoplexus-opensource/ics-admet-prediction-tdc/tree/main/", 
+		"https://github.com/Innoplexus-opensource/ics-admet-prediction-tdc/tree/main/report/Innoplexus ADME-NN Model Evaluation on TDC Benchmark ADMET Group Binary Datasets.pdf",
+		"305,794", 0.978
+	    ],        
             [
                 "CFA", "Nan Jiang", "njiang3@fordham.edu", "https://github.com/F-LIDM/CFA4DD", 
                 "https://chemrxiv.org/engage/chemrxiv/article-details/6563ec17cf8b3c3cd73212b3", "N/A", 0.920
@@ -681,6 +755,10 @@ _LEADERBOARDS = {
             ],
         ],
         [
+            [
+		0.978,
+		0.004
+	    ],
             [
                 0.920,
                 0.006
@@ -731,6 +809,12 @@ _LEADERBOARDS = {
         "incr",
         [
             [
+		"Innoplexus ABDNN-ADME", "Rohit Yadav", "rohit.yadav@ics.innoplexus.com",
+		"https://github.com/Innoplexus-opensource/ics-admet-prediction-tdc/tree/main/", 
+		"https://github.com/Innoplexus-opensource/ics-admet-prediction-tdc/tree/main/report/Innoplexus ADME-NN Model Evaluation on TDC Benchmark ADMET Group Binary Datasets.pdf",
+		"305,794", 3.744
+	    ],
+            [
                 "MapLight + GNN", "Jim Notwell", "jnotwell@maplightrx.com", "https://github.com/maplightrx/MapLight-TDC", 
                 "https://arxiv.org/abs/2310.00174", "N/A", 7.526
             ],
@@ -755,8 +839,7 @@ _LEADERBOARDS = {
                 "https://pubs.acs.org/doi/full/10.1021/acs.jcim.9b00237", "N/A", 8.288
             ],
             [
-                "Innoplexus ADME", "Rohit Yadav", "rohit.yadav@ics.innoplexus.com", 
-                "https://github.com/Innoplexus-opensource/ics-therapeutics-data-commons/tree/main", 
+                "Innoplexus ADME", "Rohit Yadav", "rohit.yadav@ics.innoplexus.com", "https://github.com/Innoplexus-opensource/ics-therapeutics-data-commons/tree/main",
                 "https://github.com/Innoplexus-opensource/ics-therapeutics-data-commons/blob/main/Innoplexus_ADME_Model_report.pdf",
                 "N/A", 8.582
             ],
@@ -783,7 +866,11 @@ _LEADERBOARDS = {
                 "2,067,053", 9.445
             ]
         ],
-        [
+        [   
+            [
+		3.744,
+		0.152
+	    ],
             [
                 7.526,
                 0.106
@@ -842,12 +929,17 @@ _LEADERBOARDS = {
         "desc",
         [
             [
+		"Innoplexus ABDNN-ADME", "Rohit Yadav", "rohit.yadav@ics.innoplexus.com",
+		"https://github.com/Innoplexus-opensource/ics-admet-prediction-tdc/tree/main/", 
+		"https://github.com/Innoplexus-opensource/ics-admet-prediction-tdc/tree/main/report/Innoplexus ADME-NN Model Evaluation on TDC Benchmark ADMET Group Binary Datasets.pdf",
+		"305,794", 0.715
+	    ],
+            [
                 "MapLight + GNN", "Jim Notwell", "jnotwell@maplightrx.com", "https://github.com/maplightrx/MapLight-TDC",
                 "https://arxiv.org/abs/2310.00174", "N/A", 0.713
             ],
             [
-                "Innoplexus ADME", "Rohit Yadav", "rohit.yadav@ics.innoplexus.com", 
-                "https://github.com/Innoplexus-opensource/ics-therapeutics-data-commons/tree/main", 
+                "Innoplexus ADME", "Rohit Yadav", "rohit.yadav@ics.innoplexus.com", "https://github.com/Innoplexus-opensource/ics-therapeutics-data-commons/tree/main",
                 "https://github.com/Innoplexus-opensource/ics-therapeutics-data-commons/blob/main/Innoplexus_ADME_Model_report.pdf",
                 "N/A", 0.707
             ],
@@ -895,6 +987,10 @@ _LEADERBOARDS = {
             ],
         ],
         [
+            [
+		0.715,
+		0.043
+	    ],
             [
                 0.713,
                 0.007
@@ -953,6 +1049,12 @@ _LEADERBOARDS = {
         "desc",
         [
             [
+		"Innoplexus ABDNN-ADME", "Rohit Yadav", "rohit.yadav@ics.innoplexus.com",
+		"https://github.com/Innoplexus-opensource/ics-admet-prediction-tdc/tree/main/", 
+		"https://github.com/Innoplexus-opensource/ics-admet-prediction-tdc/tree/main/report/Innoplexus ADME-NN Model Evaluation on TDC Benchmark ADMET Group Binary Datasets.pdf",
+		"305,794", 0.958
+	    ],
+            [
                 "MapLight + GNN", "Jim Notwell", "jnotwell@maplightrx.com", "https://github.com/maplightrx/MapLight-TDC",
                 "https://arxiv.org/abs/2310.00174", "N/A", 0.859
             ],
@@ -1001,7 +1103,11 @@ _LEADERBOARDS = {
                 "https://pubmed.ncbi.nlm.nih.gov/31408336/", "300,806", 0.749
             ],
         ],
-        [
+        [   
+            [
+		0.958,
+		0.006
+	    ], 
             [
                 0.859,
                 0.001
@@ -1056,6 +1162,12 @@ _LEADERBOARDS = {
         "desc",
         [
             [
+		"Innoplexus ABDNN-ADME", "Rohit Yadav", "rohit.yadav@ics.innoplexus.com",
+		"https://github.com/Innoplexus-opensource/ics-admet-prediction-tdc/tree/main/", 
+		"https://github.com/Innoplexus-opensource/ics-admet-prediction-tdc/tree/main/report/Innoplexus ADME-NN Model Evaluation on TDC Benchmark ADMET Group Binary Datasets.pdf",
+		"305,794", 0.936
+	    ],
+            [
                 "MapLight + GNN", "Jim Notwell", "jnotwell@maplightrx.com", "https://github.com/maplightrx/MapLight-TDC", 
                 "https://arxiv.org/abs/2310.00174", "N/A", 0.790
             ],
@@ -1105,6 +1217,10 @@ _LEADERBOARDS = {
             ],
         ],
         [
+            [
+		0.936,
+		0.013
+	    ],
             [
                 0.790,
                 0.001
@@ -1159,6 +1275,12 @@ _LEADERBOARDS = {
         "desc",
         [
             [
+		"Innoplexus ABDNN-ADME", "Rohit Yadav", "rohit.yadav@ics.innoplexus.com",
+		"https://github.com/Innoplexus-opensource/ics-admet-prediction-tdc/tree/main/", 
+		"https://github.com/Innoplexus-opensource/ics-admet-prediction-tdc/tree/main/report/Innoplexus ADME-NN Model Evaluation on TDC Benchmark ADMET Group Binary Datasets.pdf",
+		"305,794", 0.975
+	    ],
+            [
                 "MapLight + GNN", "Jim Notwell", "jnotwell@maplightrx.com", "https://github.com/maplightrx/MapLight-TDC",
                 "https://arxiv.org/abs/2310.00174", "N/A", 0.916
             ],
@@ -1203,6 +1325,10 @@ _LEADERBOARDS = {
             ],
         ],
         [
+            [
+		0.975,
+		0.005
+	    ],
             [
                 0.916,
                 0.000
@@ -1251,7 +1377,13 @@ _LEADERBOARDS = {
         "old",
         ["Rank", "Model", "Contact", "Link", "#Params", "AUPRC"],
         "desc",
-        [
+        [   
+            [
+		"Innoplexus ABDNN-ADME", "Rohit Yadav", "rohit.yadav@ics.innoplexus.com",
+		"https://github.com/Innoplexus-opensource/ics-admet-prediction-tdc/tree/main/", 
+		"https://github.com/Innoplexus-opensource/ics-admet-prediction-tdc/tree/main/report/Innoplexus ADME-NN Model Evaluation on TDC Benchmark ADMET Group Binary Datasets.pdf",
+		"305,794", 0.913
+	    ],
             [
                 "ZairaChem", "Gemma Turon", "gemma@ersilia.io", "https://github.com/ersilia-os/zaira-chem-tdc-benchmark", 
                 "https://www.biorxiv.org/content/10.1101/2022.12.13.520154v1", "N/A", 0.441
@@ -1299,7 +1431,11 @@ _LEADERBOARDS = {
                 "https://arxiv.org/abs/1905.12265", "2,067,053", 0.381
             ]
         ],
-        [
+        [   
+            [
+		0.913,
+		0.038
+	    ],
             [
                 0.441,
                 0.033
@@ -1352,7 +1488,13 @@ _LEADERBOARDS = {
         "old",
         ["Rank", "Model", "Contact", "Link", "#Params", "AUPRC"],
         "desc",
-        [
+        [   
+            [
+		"Innoplexus ABDNN-ADME", "Rohit Yadav", "rohit.yadav@ics.innoplexus.com",
+		"https://github.com/Innoplexus-opensource/ics-admet-prediction-tdc/tree/main/", 
+		"https://github.com/Innoplexus-opensource/ics-admet-prediction-tdc/tree/main/report/Innoplexus ADME-NN Model Evaluation on TDC Benchmark ADMET Group Binary Datasets.pdf",
+		"305,794", 0.983
+	    ], 
             [
                 "ContextPred", "Kexin Huang", "kexinh@stanford.edu", "https://github.com/mims-harvard/TDC/tree/main/examples/single_pred/admet",
                 "https://arxiv.org/abs/1905.12265", "2,067,053", 0.736
@@ -1401,6 +1543,10 @@ _LEADERBOARDS = {
             ]
         ],
         [
+            [
+		0.983,
+		0.013
+	    ],
             [
                 0.736,
                 0.024
@@ -1451,6 +1597,12 @@ _LEADERBOARDS = {
         "desc",
         [
             [
+		"Innoplexus ABDNN-ADME", "Rohit Yadav", "rohit.yadav@ics.innoplexus.com",
+		"https://github.com/Innoplexus-opensource/ics-admet-prediction-tdc/tree/main/", 
+		"https://github.com/Innoplexus-opensource/ics-admet-prediction-tdc/tree/main/report/Innoplexus ADME-NN Model Evaluation on TDC Benchmark ADMET Group Binary Datasets.pdf",
+		"305,794", 0.975
+	    ],
+            [
                 "CFA", "Nan Jiang", "njiang3@fordham.edu", "https://github.com/F-LIDM/CFA4DD", 
                 "https://chemrxiv.org/engage/chemrxiv/article-details/6563ec17cf8b3c3cd73212b3", "N/A", 0.667
             ],
@@ -1499,6 +1651,10 @@ _LEADERBOARDS = {
             ]
         ],
         [
+            [
+		0.975,
+		0.008
+	    ],
             [
                 0.667,
                 0.019
@@ -1582,6 +1738,12 @@ _LEADERBOARDS = {
                 "https://doi.org/10.1101/2024.05.27.595849", "N/A", 0.485
             ],
             [
+		"Innoplexus ABDNN-ADME", "Rohit Yadav", "rohit.yadav@ics.innoplexus.com",
+		"https://github.com/Innoplexus-opensource/ics-admet-prediction-tdc/tree/main/", 
+		"https://github.com/Innoplexus-opensource/ics-admet-prediction-tdc/tree/main/report/Innoplexus ADME-NN Model Evaluation on TDC Benchmark ADMET Group Binary Datasets.pdf",
+		"305,794", 0.445
+	    ],
+            [
                 "Basic ML", "Nilavo Boral", "nilavoboral@gmail.com", "https://github.com/NilavoBoral/Therapeutics-Data-Commons",
                 "https://www.biorxiv.org/content/10.1101/2022.06.29.115436v1", "N/A", 0.438
             ],
@@ -1632,6 +1794,10 @@ _LEADERBOARDS = {
                 0.039
             ],
             [
+		0.445,
+		0.078
+	    ],
+            [
                 0.438,
                 0.011
             ],
@@ -1661,6 +1827,12 @@ _LEADERBOARDS = {
         "desc",
         [
             [
+		"Innoplexus ABDNN-ADME", "Rohit Yadav", "rohit.yadav@ics.innoplexus.com",
+		"https://github.com/Innoplexus-opensource/ics-admet-prediction-tdc/tree/main/", 
+		"https://github.com/Innoplexus-opensource/ics-admet-prediction-tdc/tree/main/report/Innoplexus ADME-NN Model Evaluation on TDC Benchmark ADMET Group Binary Datasets.pdf",
+		"305,794", 0.789
+	    ],
+            [
                 "CFA", "Nan Jiang", "njiang3@fordham.edu", "https://github.com/F-LIDM/CFA4DD", 
                 "https://chemrxiv.org/engage/chemrxiv/article-details/6563ec17cf8b3c3cd73212b3", "N/A", 0.536
             ],
@@ -1673,8 +1845,7 @@ _LEADERBOARDS = {
                 "https://arxiv.org/abs/2310.00174", "N/A", 0.466
             ],
             [
-                "Innoplexus ADME", "Rohit Yadav", "rohit.yadav@ics.innoplexus.com", 
-                "https://github.com/Innoplexus-opensource/ics-therapeutics-data-commons/tree/main", 
+                "Innoplexus ADME", "Rohit Yadav", "rohit.yadav@ics.innoplexus.com", "https://github.com/Innoplexus-opensource/ics-therapeutics-data-commons/tree/main",
                 "https://github.com/Innoplexus-opensource/ics-therapeutics-data-commons/blob/main/Innoplexus_ADME_Model_report.pdf",
                 "N/A", 0.457
             ],
@@ -1712,6 +1883,10 @@ _LEADERBOARDS = {
             ]
         ],
         [
+            [
+		0.789,
+		0.019
+	    ],
             [
                 0.536,
                 0.020
@@ -1770,6 +1945,12 @@ _LEADERBOARDS = {
         "desc",
         [
             [
+		"Innoplexus ABDNN-ADME", "Rohit Yadav", "rohit.yadav@ics.innoplexus.com",
+		"https://github.com/Innoplexus-opensource/ics-admet-prediction-tdc/tree/main/", 
+		"https://github.com/Innoplexus-opensource/ics-admet-prediction-tdc/tree/main/report/Innoplexus ADME-NN Model Evaluation on TDC Benchmark ADMET Group Binary Datasets.pdf",
+		"305,794", 0.783
+	    ],
+            [
                 "MapLight + GNN", "Jim Notwell", "jnotwell@maplightrx.com", "https://github.com/maplightrx/MapLight-TDC",
                 "https://arxiv.org/abs/2310.00174", "N/A", 0.630
             ],
@@ -1784,6 +1965,11 @@ _LEADERBOARDS = {
             [
                 "RFStacker", "Andrew Li", "andrew@oloren.ai", "https://github.com/Oloren-AI/OCE-TDC/blob/main/submission.ipynb",
                 "https://github.com/Oloren-AI/OCE-TDC/blob/main/Report.pdf", "1,858,225", 0.625
+            ],
+            [     
+                "Innoplexus ADME", "Rohit Yadav", "rohit.yadav@ics.innoplexus.com", "https://github.com/Innoplexus-opensource/ics-therapeutics-data-commons/tree/main",
+                "https://github.com/Innoplexus-opensource/ics-therapeutics-data-commons/blob/main/Innoplexus_ADME_Model_report.pdf",
+                "N/A", 0.620
             ],
             [
                 "Chemprop-RDKit", "Kyle Swanson", "swansonk@stanford.edu", "https://github.com/chemprop/chemprop", 
@@ -1812,6 +1998,10 @@ _LEADERBOARDS = {
         ],
         [
             [
+		0.783,
+		0.039
+	    ],
+            [
                 0.630,
                 0.010
             ],
@@ -1826,6 +2016,10 @@ _LEADERBOARDS = {
             [
                 0.625,
                 0.002
+            ],
+            [            
+                0.620,
+                0.007
             ],
             [
                 0.599,
@@ -1861,8 +2055,19 @@ _LEADERBOARDS = {
         "incr",
         [
             [
+		"Innoplexus ABDNN-ADME", "Rohit Yadav", "rohit.yadav@ics.innoplexus.com",
+		"https://github.com/Innoplexus-opensource/ics-admet-prediction-tdc/tree/main/", 
+		"https://github.com/Innoplexus-opensource/ics-admet-prediction-tdc/tree/main/report/Innoplexus ADME-NN Model Evaluation on TDC Benchmark ADMET Group Binary Datasets.pdf",
+		"305,794", 0.210
+	    ],
+            [
                 "BaseBoosting KyQVZ6b2", "David Huang", "david@oloren.ai", "https://github.com/Oloren-AI/OCE-TDC/tree/main",
                 "https://chemrxiv.org/engage/chemrxiv/article-details/6350b9d186473a47d31a8492", "N/A", 0.552
+            ],
+            [     
+                "Innoplexus ADME", "Rohit Yadav", "rohit.yadav@ics.innoplexus.com", "https://github.com/Innoplexus-opensource/ics-therapeutics-data-commons/tree/main",
+                "https://github.com/Innoplexus-opensource/ics-therapeutics-data-commons/blob/main/Innoplexus_ADME_Model_report.pdf",
+                "N/A", 0.588
             ],
             [
                 "MACCS keys + autoML", "Alexander Scarlat", "ascarlat@mitre.org", "https://github.com/scarlat1/AcuteToxicityLD50",
@@ -1911,8 +2116,16 @@ _LEADERBOARDS = {
         ],
         [
             [
+		0.210,
+		0.017
+	    ],
+            [
                 0.522,
                 0.009
+            ],
+            [
+                0.588,
+                0.000
             ],
             [
                 0.588,
@@ -1968,6 +2181,12 @@ _LEADERBOARDS = {
         "desc",
         [
             [
+		"Innoplexus ABDNN-ADME", "Rohit Yadav", "rohit.yadav@ics.innoplexus.com",
+		"https://github.com/Innoplexus-opensource/ics-admet-prediction-tdc/tree/main/", 
+		"https://github.com/Innoplexus-opensource/ics-admet-prediction-tdc/tree/main/report/Innoplexus ADME-NN Model Evaluation on TDC Benchmark ADMET Group Binary Datasets.pdf",
+		"305,794", 0.963
+	    ],
+            [
                 "MapLight + GNN", "Jim Notwell", "jnotwell@maplightrx.com", "https://github.com/maplightrx/MapLight-TDC",
                 "https://arxiv.org/abs/2310.00174", "N/A", 0.880
             ],
@@ -2013,6 +2232,10 @@ _LEADERBOARDS = {
             ]
         ],
         [
+            [
+		0.963,
+		0.013
+	    ],
             [
                 0.880,
                 0.002
@@ -2067,6 +2290,12 @@ _LEADERBOARDS = {
         "desc",
         [
             [
+		"Innoplexus ABDNN-ADME", "Rohit Yadav", "rohit.yadav@ics.innoplexus.com",
+		"https://github.com/Innoplexus-opensource/ics-admet-prediction-tdc/tree/main/", 
+		"https://github.com/Innoplexus-opensource/ics-admet-prediction-tdc/tree/main/report/Innoplexus ADME-NN Model Evaluation on TDC Benchmark ADMET Group Binary Datasets.pdf",
+		"305,794", 0.983
+	    ],
+            [
                 "ZairaChem", "Gemma Turon", "gemma@ersilia.io", "https://github.com/ersilia-os/zaira-chem-tdc-benchmark",
                 "https://www.biorxiv.org/content/10.1101/2022.12.13.520154v1", "N/A", 0.871
             ],
@@ -2116,6 +2345,10 @@ _LEADERBOARDS = {
             ]
         ],
         [
+            [
+		0.983,
+		0.004
+	    ],
             [
                 0.871,
                 0.002
@@ -2174,6 +2407,12 @@ _LEADERBOARDS = {
         "desc",
         [
             [
+		"Innoplexus ABDNN-ADME", "Rohit Yadav", "rohit.yadav@ics.innoplexus.com",
+		"https://github.com/Innoplexus-opensource/ics-admet-prediction-tdc/tree/main/", 
+		"https://github.com/Innoplexus-opensource/ics-admet-prediction-tdc/tree/main/report/Innoplexus ADME-NN Model Evaluation on TDC Benchmark ADMET Group Binary Datasets.pdf",
+		"305,794", 0.998
+	    ],
+            [
                 "ZairaChem", "Gemma Turon", "gemma@ersilia.io", "https://github.com/ersilia-os/zaira-chem-tdc-benchmark", 
                 "https://www.biorxiv.org/content/10.1101/2022.12.13.520154v1", "N/A", 0.925
             ],
@@ -2219,6 +2458,10 @@ _LEADERBOARDS = {
             ]
         ],
         [
+            [
+		0.998,
+		0.002
+	    ],
             [
                 0.925,
                 0.005


### PR DESCRIPTION
@amva13 This PR is for submitting new entries/ new model to the TDC ADMET Group Leaderboard.


Please find the details below as per guidelines provided here


A. A link to the codes for training the model and running the benchmarks.
https://github.com/Innoplexus-opensource/ics-admet-prediction-tdc/tree/main


B. Instructions for replicating your results running these codes.
https://github.com/Innoplexus-opensource/ics-admet-prediction-tdc/blob/main/README.md


C. Description of the hardware used for training the model.
Machine with Intel i9-13900 processor 62GB RAM and NVIDIA RTX A6000 GPU with 48GB VRAM was used for the model training experiments.


D. Link to paper to be included on the website
https://github.com/Innoplexus-opensource/ics-admet-prediction-tdc/tree/main/report/Innoplexus ADME-NN Model Evaluation on TDC Benchmark ADMET Group Binary Datasets.pdf


E. Paper authors and developers of the model.
Rohit Yadav, Divya Nair, Amit Agarwal
Innoplexus Consulting Services Pvt Ltd, a Partex company


F. The dictionary string output of running the TDC benchmark group evaluations.
"Innoplexus ABDNN-ADME" (New model):
{{'caco2_wang': [0.148, 0.007]}, {'bioavailability_ma': [0.955, 0.017]}, {'lipophilicity_astrazeneca': [0.227, 0.018]}, {'solubility_aqsoldb': [0.387, 0.035]}, {'hia_hou': [0.985, 0.029]}, {'pgp_broccatelli': [0.985, 0.006]}, {'bbb_martins': [0.978, 0.004]}, {'ppbr_az': [3.744, 0.152]}, {'vdss_lombardo': [0.715, 0.043]}, {'cyp2c9_veith': [0.958, 0.006]}, {'cyp2d6_veith': [0.936, 0.013]}, {'cyp3a4_veith': [0.975, 0.005]}, {'cyp2c9_substrate_carbonmangels': [0.913, 0.038]}, {'cyp2d6_substrate_carbonmangels': [0.983, 0.013]}, {'cyp3a4_substrate_carbonmangels': [0.975, 0.008]}, {'half_life_obach': [0.445, 0.078]}, {'clearance_hepatocyte_az': [0.789, 0.019]}, {'clearance_microsome_az': [0.783, 0.039]}, {'ld50_zhu': [0.21, 0.017]}, {'herg': [0.963, 0.013]}, {'ames': [0.983, 0.004]}, {'dili': [0.998, 0.002]}, {'herg': [0.966, 0.009]}}


Kindly review and merge this PR. Also earlier we submitted "Innoplexus ADME" (Old model), There were some benchmark rankings missing from the leaderboard, i will provide additional PR for that as well for correction.


@amva13 the below PR is for correcting old entries/ old model to the TDC ADMET Group Leaderboard.


A. A link to the codes for training the model and running the benchmarks.
https://github.com/Innoplexus-opensource/ics-therapeutics-data-commons/tree/main


B. Instructions for replicating your results running these codes.
https://github.com/Innoplexus-opensource/ics-therapeutics-data-commons/blob/main/README.md


C. Description of the hardware used for training the model.
Machine with Intel i9-13900 processor 62GB RAM and NVIDIA RTX A6000 GPU with 48GB VRAM was used for the model training experiments.


D. Link to paper to be included on the website
https://github.com/Innoplexus-opensource/ics-therapeutics-data-commons/blob/main/Innoplexus_ADME_Model_report.pdf


E. Paper authors and developers of the model.
Rohit Yadav^1, Divya Nair^1, Prajakta Mate^1, Rushikesh Chaudhari^1, Arpan Sheetal^1, Sudhir Mansukh^1, Amit Agarwal^1, Anand Muglikar^2
1.Innoplexus Consulting Services Pvt Ltd, a Partex company
2.Perpetualblock Technologies Private Limited, a Partex company


F. The dictionary string output of running the TDC benchmark group evaluations.
"Innoplexus ADME" (Old model):
{{'caco2_wang': [0.289, 0.005]}, {'lipophilicity_astrazeneca': [0.499, 0.003]}, {'solubility_aqsoldb': [0.771, 0.005]}, {'ppbr_az': [8.582, 0.036]}, {'vdss_lombardo': [0.707, 0.006]}, {'half_life_obach': [0.511, 0.000]}, {'clearance_hepatocyte_az': [0.457, 0.013]}, {'clearance_microsome_az': [0.620, 0.007]}, {'ld50_zhu': [0.588, 0.000]}}